### PR TITLE
Initialise ES register on Truename call

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 if [ x"${COMPILER}" = "xgcc" ] ; then
   # Note requires installation of libi86-ia16-elf DOS compat library
   export CC="ia16-elf-gcc"
-  export CFLAGS="-Wall -fpack-struct -mcmodel=small -o "
+  export CFLAGS="-Wall -fpack-struct -mcmodel=small -Os -o "
   export LDFLAGS="-li86"
   TARGET="label.exe"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -85,7 +85,7 @@ endif
 #EXEFLAGS=-ffreestanding -mrtd 
 EXEFLAGS?=
 LDFLAGS?=-li86
-CFLAGS?=-I../kitten -mcmodel=small  -fpack-struct -Werror -fno-strict-aliasing $(EXEFLAGS) -o 
+CFLAGS?=-I../kitten -mcmodel=small -fpack-struct -Werror -Os -fno-strict-aliasing $(EXEFLAGS) -o 
 endif
 
 ifeq ($(COMPILER),cl)

--- a/src/label.c
+++ b/src/label.c
@@ -279,8 +279,10 @@ int valid_drive(char *s)
     strcpy(buf1, TempDrive);
     strcat(buf1, "\\");
     segread(&sregs);
-    regs.x.si = (unsigned)buf1; /* needs NEAR POINTER */
-    regs.x.di = (unsigned)buf2; /* needs NEAR POINTER */
+    sregs.ds = FP_SEG(buf1);
+    regs.x.si = FP_OFF(buf1);
+    sregs.es = FP_SEG(buf2);
+    regs.x.di = FP_OFF(buf2);
     regs.x.ax = 0x6000;
     intdosx(&regs, &regs, &sregs);
     if (*buf1 != *buf2)


### PR DESCRIPTION
I've tweaked this as per @tkchia's diagnosis. I don't have a test environment setup to run `label` with real drives etc. Any chance you could give it a quick test, please?